### PR TITLE
Fix bug: Hex Payload not work when not check timestamp

### DIFF
--- a/mqtt_jmeter/src/main/java/net/xmeter/samplers/PubSampler.java
+++ b/mqtt_jmeter/src/main/java/net/xmeter/samplers/PubSampler.java
@@ -92,27 +92,24 @@ public class PubSampler extends AbstractMQTTSampler implements ThreadListener {
 		result.setSampleLabel(getName());
 		try {
 			String topicName = getTopic();
-			byte[] toSend = new byte[0];
-			
+
+			byte[] toSend = new byte[]{};
+			byte[] tmp = new byte[]{};
+
+			if (MESSAGE_TYPE_HEX_STRING.equals(getMessageType())) {
+				tmp = hexToBinary(getMessage());
+			} else if (MESSAGE_TYPE_STRING.equals(getMessageType())) {
+				tmp = getMessage().getBytes();
+			} else if(MESSAGE_TYPE_RANDOM_STR_WITH_FIX_LEN.equals(getMessageType())) {
+				tmp = payload.getBytes();
+			}
+
 			if (isAddTimestamp()) {
 				byte[] timePrefix = (System.currentTimeMillis() + TIME_STAMP_SEP_FLAG).getBytes();
-				byte[] tmp = new byte[]{};
-				if (MESSAGE_TYPE_HEX_STRING.equals(getMessageType())) {
-					tmp = hexToBinary(getMessage());
-				} else if (MESSAGE_TYPE_STRING.equals(getMessageType())) {
-					tmp = getMessage().getBytes();
-				} else if(MESSAGE_TYPE_RANDOM_STR_WITH_FIX_LEN.equals(getMessageType())) {
-					tmp = payload.getBytes();
-				}
 				toSend = new byte[timePrefix.length + tmp.length];
 				System.arraycopy(timePrefix, 0, toSend, 0, timePrefix.length);
 				System.arraycopy(tmp, 0, toSend, timePrefix.length , tmp.length);
 			} else {
-				byte[] tmp = getMessage().getBytes("utf-8");
-				
-				if(MESSAGE_TYPE_RANDOM_STR_WITH_FIX_LEN.equals(getMessageType())) {
-					tmp = payload.getBytes("utf-8");
-				}
 				toSend = new byte[tmp.length];
 				System.arraycopy(tmp, 0, toSend, 0 , tmp.length);
 			}


### PR DESCRIPTION
“Add timestamp to payload" 没有选中的情况下，不能发布hex string类型的payload消息