### PR TITLE
Add support for mqtt5

### DIFF
--- a/mqtt_jmeter/pom.xml
+++ b/mqtt_jmeter/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>net.xmeter</groupId>
     <artifactId>mqtt-jmeter</artifactId>
-    <version>2.0.2</version>
+    <version>2.0.3</version>
 
     <properties>
         <jmeter-version>5.5</jmeter-version>
@@ -35,6 +35,24 @@
             <groupId>com.hivemq</groupId>
             <artifactId>hivemq-mqtt-client</artifactId>
             <version>1.3.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.paho</groupId>
+            <artifactId>org.eclipse.paho.client.mqttv3</artifactId>
+            <version>1.2.5</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.paho</groupId>
+            <artifactId>org.eclipse.paho.mqttv5.client</artifactId>
+            <version>1.2.5</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcpkix-jdk15on</artifactId>
+            <version>1.70</version>
         </dependency>
 
         <dependency>

--- a/mqtt_jmeter/src/main/java/net/xmeter/Constants.java
+++ b/mqtt_jmeter/src/main/java/net/xmeter/Constants.java
@@ -9,6 +9,7 @@ public interface Constants {
 
 	public static final String PROTOCOL = "mqtt.protocol";
 	public static final String WS_PATH = "mqtt.ws_path";
+	public static final String WS_HEADER = "mqtt.ws_header";
 	public static final String DUAL_AUTH = "mqtt.dual_ssl_authentication";
 	public static final String CERT_FILE_PATH1 = "mqtt.keystore_file_path";
 	public static final String CERT_FILE_PATH2 = "mqtt.clientcert_file_path";
@@ -17,6 +18,8 @@ public interface Constants {
 	
 	public static final String USER_NAME_AUTH = "mqtt.user_name";
 	public static final String PASSWORD_AUTH = "mqtt.password";
+	public static final String AUTH_METHOD = "mqtt.auth_method";
+	public static final String AUTH_DATA = "mqtt.auth_data";
 	
 	public static final String CONN_CLIENT_ID_PREFIX = "mqtt.client_id_prefix";
 	public static final String CONN_CLIENT_ID_SUFFIX = "mqtt.client_id_suffix";
@@ -26,6 +29,10 @@ public interface Constants {
 	public static final String CONN_RECONN_ATTEMPT_MAX = "mqtt.reconn_attempt_max";
 	
 	public static final String CONN_CLEAN_SESSION = "mqtt.conn_clean_session";
+
+	public static final String CONN_USER_PROPERTY = "mqtt.conn_user_property";
+	public static final String CONN_CLEAN_START = "mqtt.conn_clean_start";
+	public static final String CONN_SESSION_EXPIRY_INTERVAL = "mqtt.conn_session_expiry_interval";
 	
 	public static final String MESSAGE_TYPE = "mqtt.message_type";
 	public static final String MESSAGE_FIX_LENGTH = "mqtt.message_type_fixed_length";
@@ -35,6 +42,15 @@ public interface Constants {
 	public static final String QOS_LEVEL = "mqtt.qos_level";
 	public static final String ADD_TIMESTAMP = "mqtt.add_timestamp";
 	public static final String RETAINED_MESSAGE = "mqtt.retained_message";
+
+	public static final String CORRELATION_DATA = "mqtt.correlation_data";
+	public static final String MESSAGE_EXPIRY_INTERVAL = "mqtt.message_expiry_interval";
+	public static final String USER_PROPERTIES = "mqtt.user_properties";
+	public static final String CONTENT_TYPE = "mqtt.content_type";
+	public static final String RESPONSE_TOPIC = "mqtt.response_topic";
+	public static final String PAYLOAD_FORMAT = "mqtt.payload_format_indicator";
+	public static final String TOPIC_ALIAS = "mqtt.topic_alias";
+	public static final String SUBSCRIPTION_IDENTIFIER = "mqtt.subscription_identifier";
 	
 	public static final String SAMPLE_CONDITION_VALUE = "mqtt.sample_condition_value";
 	public static final String SAMPLE_CONDITION = "mqtt.sample_condition";
@@ -53,7 +69,7 @@ public interface Constants {
 	
 	public static final String MQTT_VERSION_3_1_1 = "3.1.1";
 	public static final String MQTT_VERSION_3_1 = "3.1";
-	
+	public static final String MQTT_VERSION_5_0 = "5.0";
 	public static final String SAMPLE_ON_CONDITION_OPTION1 = "specified elapsed time (ms)";
 	public static final String SAMPLE_ON_CONDITION_OPTION2 = "number of received messages";
 	
@@ -69,9 +85,10 @@ public interface Constants {
 	public static final String WSS_PROTOCOL = "WSS";
 	public static final String DEFAULT_PROTOCOL = TCP_PROTOCOL;
 	public static final String FUSESOURCE_MQTT_CLIENT_NAME = "fusesource";
+	public static final String PAHO_MQTT_CLIENT_NAME = "paho";
 	public static final String HIVEMQ_MQTT_CLIENT_NAME = "hivemq";
 //	public static final String DEFAULT_MQTT_CLIENT_NAME = FUSESOURCE_MQTT_CLIENT_NAME;
-	public static final String DEFAULT_MQTT_CLIENT_NAME = HIVEMQ_MQTT_CLIENT_NAME;
+	public static final String DEFAULT_MQTT_CLIENT_NAME = PAHO_MQTT_CLIENT_NAME;
 	
 	public static final String JMETER_VARIABLE_PREFIX = "${";
 	
@@ -82,6 +99,7 @@ public interface Constants {
 	public static final String DEFAULT_CONN_KEEP_ALIVE = "300";
 	public static final String DEFAULT_CONN_ATTEMPT_MAX = "0";
 	public static final String DEFAULT_CONN_RECONN_ATTEMPT_MAX = "0";
+	public static final String DEFAULT_CONN_USER_PROPERTY = "{}";
 	
 	public static final String DEFAULT_SAMPLE_VALUE_COUNT = "1";
 	public static final String DEFAULT_SAMPLE_VALUE_ELAPSED_TIME_MILLI_SEC = "1000";

--- a/mqtt_jmeter/src/main/java/net/xmeter/gui/CommonConnUI.java
+++ b/mqtt_jmeter/src/main/java/net/xmeter/gui/CommonConnUI.java
@@ -35,8 +35,6 @@ public class CommonConnUI implements ChangeListener, ActionListener, Constants{
 	
 	private final JLabeledTextField userNameAuth = new JLabeledTextField("User name:");
 	private final JLabeledTextField passwordAuth = new JLabeledTextField("Password:");
-	private final JLabeledTextField authMethod = new JLabeledTextField("Auth Method:");
-	private final JLabeledTextField authData = new JLabeledTextField("Auth Data:");
 
 	private JLabeledChoice protocols;
 //	private JLabeledChoice clientNames;
@@ -142,13 +140,6 @@ public class CommonConnUI implements ChangeListener, ActionListener, Constants{
 		optsPanel.add(userNameAuth);
 		optsPanel.add(passwordAuth);
 		optsPanelCon.add(optsPanel);
-
-//		JPanel optsPanel1 = new HorizontalPanel();
-//		optsPanel1.add(authMethod);
-//		optsPanel1.add(authData);
-//		authMethod.setVisible(false);
-//		authData.setVisible(false);
-//		optsPanelCon.add(optsPanel1);
 		
 		return optsPanelCon;
 	}
@@ -350,8 +341,6 @@ public class CommonConnUI implements ChangeListener, ActionListener, Constants{
 			connCleanStart.setVisible(isMqtt5);
 			connSessionExpiryInterval.setVisible(isMqtt5);
 			connCleanSession.setVisible(!isMqtt5);
-//			authMethod.setVisible(isMqtt5);
-//			authData.setVisible(isMqtt5);
 		}
 	}
 
@@ -403,8 +392,6 @@ public class CommonConnUI implements ChangeListener, ActionListener, Constants{
 
 		userNameAuth.setText(sampler.getUserNameAuth());
 		passwordAuth.setText(sampler.getPasswordAuth());
-//		authMethod.setText(sampler.getAuthMethod());
-//		authData.setText(sampler.getAuthData());
 		
 		connNamePrefix.setText(sampler.getConnPrefix());
 		if (sampler.isClientIdSuffix()) {
@@ -447,8 +434,6 @@ public class CommonConnUI implements ChangeListener, ActionListener, Constants{
 
 		sampler.setUserNameAuth(userNameAuth.getText());
 		sampler.setPasswordAuth(passwordAuth.getText());
-//		sampler.setAuthMethod(authMethod.getText());
-//		sampler.setAuthData(authData.getText());
 
 		sampler.setConnPrefix(connNamePrefix.getText());
 		sampler.setClientIdSuffix(connNameSuffix.isSelected());
@@ -495,8 +480,6 @@ public class CommonConnUI implements ChangeListener, ActionListener, Constants{
 		
 		userNameAuth.setText("");
 		passwordAuth.setText("");
-//		authMethod.setText("");
-//		authData.setText("");
 
 		connNamePrefix.setText(DEFAULT_CONN_PREFIX_FOR_CONN);
 		connNameSuffix.setSelected(true);

--- a/mqtt_jmeter/src/main/java/net/xmeter/gui/PubSamplerUI.java
+++ b/mqtt_jmeter/src/main/java/net/xmeter/gui/PubSamplerUI.java
@@ -3,9 +3,7 @@ package net.xmeter.gui;
 import java.awt.BorderLayout;
 import java.util.logging.Logger;
 
-import javax.swing.BorderFactory;
-import javax.swing.JCheckBox;
-import javax.swing.JPanel;
+import javax.swing.*;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 
@@ -29,6 +27,18 @@ public class PubSamplerUI extends AbstractSamplerGui implements Constants, Chang
 	private final JLabeledTextField retainedMsg = new JLabeledTextField("Retained messages:", 1);
 	private final JLabeledTextField topicName = new JLabeledTextField("Topic name:");
 	private JCheckBox timestamp = new JCheckBox("Add timestamp in payload");
+
+	private final JLabeledTextField messageExpiryInterval = new JLabeledTextField("Message Expiry Interval(s):");
+	private final JLabeledTextField contentType = new JLabeledTextField("Content Type:");
+	private final JLabeledTextField responseTopic = new JLabeledTextField("Response Topic:");
+	private final JLabeledTextField correlationData = new JLabeledTextField("Correlation Data:");
+	private final JLabeledTextField userProperties = new JLabeledTextField("User Properties:");
+
+	private final JLabel qosLabel = new JLabel("QoS Level:");
+	private final JLabel payloadFormatLabel = new JLabel("Payload Format:");
+	private final JLabeledChoice payloadFormat = new JLabeledChoice("Payload Format:", new String[] { "UNSPECIFIED", "UTF_8" }, false, false);
+	private final JLabeledTextField topicAlias = new JLabeledTextField("Topic Alias:");
+	private final JLabeledTextField subscriptionIdentifier = new JLabeledTextField("Subscription Identifier:");
 
 	private JLabeledChoice messageTypes;
 	private final JSyntaxTextArea sendMessage = JSyntaxTextArea.getInstance(10, 50);
@@ -59,12 +69,29 @@ public class PubSamplerUI extends AbstractSamplerGui implements Constants, Chang
 		qosChoice.addChangeListener(this);
 
 		JPanel optsPanel = new HorizontalPanel();
+		optsPanel.add(qosLabel);
 		optsPanel.add(qosChoice);
 		optsPanel.add(retainedMsg);
 		optsPanel.add(topicName);
 		topicName.setToolTipText("Name of topic that the message will be sent to.");
 		optsPanel.add(timestamp);
 		optsPanelCon.add(optsPanel);
+
+		JPanel optsPanel1 = new HorizontalPanel();
+		optsPanel1.add(userProperties);
+		optsPanel1.add(messageExpiryInterval);
+		optsPanel1.add(topicAlias);
+		optsPanel1.add(payloadFormatLabel);
+		optsPanel1.add(payloadFormat);
+		payloadFormat.setToolTipText("Payload format indicator to the message");
+		optsPanelCon.add(optsPanel1);
+
+		JPanel optsPanel2 = new HorizontalPanel();
+		optsPanel2.add(contentType);
+		optsPanel2.add(responseTopic);
+		optsPanel2.add(correlationData);
+		optsPanel2.add(subscriptionIdentifier);
+		optsPanelCon.add(optsPanel2);
 
 		return optsPanelCon;
 	}
@@ -129,7 +156,7 @@ public class PubSamplerUI extends AbstractSamplerGui implements Constants, Chang
 		super.configure(element);
 		PubSampler sampler = (PubSampler) element;
 		
-		if(sampler.getQOS().trim().indexOf(JMETER_VARIABLE_PREFIX) == -1){
+		if(sampler.getQOS().trim().contains(JMETER_VARIABLE_PREFIX)){
 			this.qosChoice.setSelectedIndex(Integer.parseInt(sampler.getQOS()));	
 		} else {
 			this.qosChoice.setText(sampler.getQOS());
@@ -149,6 +176,15 @@ public class PubSamplerUI extends AbstractSamplerGui implements Constants, Chang
 		
 		stringLength.setText(String.valueOf(sampler.getMessageLength()));
 		sendMessage.setText(sampler.getMessage());
+
+		contentType.setText(sampler.getContentType());
+		messageExpiryInterval.setText(String.valueOf(sampler.getMessageExpiryInterval()));
+		userProperties.setText(sampler.getUserProperties());
+		responseTopic.setText(sampler.getResponseTopic());
+		correlationData.setText(sampler.getCorrelationData());
+		payloadFormat.setText(sampler.getPayloadFormat());
+		topicAlias.setText(sampler.getTopicAlias());
+		subscriptionIdentifier.setText(sampler.getSubscriptionIdentifier());
 	}
 
 	@Override
@@ -161,7 +197,7 @@ public class PubSamplerUI extends AbstractSamplerGui implements Constants, Chang
 		this.configureTestElement(sampler);
 		sampler.setTopic(this.topicName.getText());
 		
-		if(this.qosChoice.getText().indexOf(JMETER_VARIABLE_PREFIX) == -1) {
+		if(this.qosChoice.getText().contains(JMETER_VARIABLE_PREFIX)) {
 			int qos = QOS_0;
 			try {
 				qos = Integer.parseInt(this.qosChoice.getText());
@@ -183,6 +219,15 @@ public class PubSamplerUI extends AbstractSamplerGui implements Constants, Chang
 		sampler.setMessageLength(this.stringLength.getText());
 		sampler.setMessage(this.sendMessage.getText());
 		sampler.setRetainedMessage(Boolean.parseBoolean(this.retainedMsg.getText()));
+
+		sampler.setContentType(this.contentType.getText());
+		sampler.setCorrelationData(this.correlationData.getText());
+		sampler.setMessageExpiryInterval(Long.parseLong(this.messageExpiryInterval.getText()));
+		sampler.setUserProperties(this.userProperties.getText());
+		sampler.setResponseTopic(this.responseTopic.getText());
+		sampler.setPayloadFormat(this.payloadFormat.getText());
+		sampler.setTopicAlias(this.topicAlias.getText());
+		sampler.setSubscriptionIdentifier(this.subscriptionIdentifier.getText());
 	}
 
 	@Override
@@ -195,5 +240,14 @@ public class PubSamplerUI extends AbstractSamplerGui implements Constants, Chang
 		this.messageTypes.setSelectedIndex(0);
 		this.stringLength.setText(String.valueOf(DEFAULT_MESSAGE_FIX_LENGTH));
 		this.sendMessage.setText("");
+
+		this.messageExpiryInterval.setText("0");
+		this.responseTopic.setText("");
+		this.contentType.setText("");
+		this.userProperties.setText("{}");
+		this.correlationData.setText("");
+		this.payloadFormat.setSelectedIndex(0);
+		this.topicAlias.setText("");
+		this.subscriptionIdentifier.setText("");
 	}
 }

--- a/mqtt_jmeter/src/main/java/net/xmeter/samplers/AbstractMQTTSampler.java
+++ b/mqtt_jmeter/src/main/java/net/xmeter/samplers/AbstractMQTTSampler.java
@@ -257,22 +257,6 @@ public abstract class AbstractMQTTSampler extends AbstractSampler implements Con
 		setProperty("mqtt.client_key_file_path", key);
 	}
 
-	public String getAuthMethod() {
-		return getPropertyAsString(AUTH_METHOD, "");
-	}
-
-	public void setAuthMethod(String authMethod) {
-		setProperty(AUTH_METHOD, authMethod);
-	}
-
-	public String getAuthData() {
-		return getPropertyAsString(AUTH_DATA, "");
-	}
-
-	public void setAuthData(String authData) {
-		setProperty(AUTH_DATA, authData);
-	}
-
 //	public int getConCapacity() {
 //		return conCapacity;
 //	}

--- a/mqtt_jmeter/src/main/java/net/xmeter/samplers/AbstractMQTTSampler.java
+++ b/mqtt_jmeter/src/main/java/net/xmeter/samplers/AbstractMQTTSampler.java
@@ -72,6 +72,14 @@ public abstract class AbstractMQTTSampler extends AbstractSampler implements Con
 		setProperty(WS_PATH, wsPath);
 	}
 
+	public String getWsHeader() {
+		return getPropertyAsString(WS_HEADER, "{}");
+	}
+
+	public void setWsHeader(String wsHeader) {
+		setProperty(WS_HEADER, wsHeader);
+	}
+
 	public boolean isDualSSLAuth() {
 		return getPropertyAsBoolean(DUAL_AUTH, false);
 	}
@@ -199,6 +207,70 @@ public abstract class AbstractMQTTSampler extends AbstractSampler implements Con
 
 	public void setMqttClientName(String mqttClientName) {
 		setProperty(MQTT_CLIENT_NAME, mqttClientName);
+	}
+
+	public void setConnCleanStart(String cleanStart) {
+		setProperty(CONN_CLEAN_START, cleanStart);
+	}
+
+	public String getConnCleanStart() {
+		return getPropertyAsString(CONN_CLEAN_START, "true");
+	}
+
+	public String getConnSessionExpiryInterval() {
+		return getPropertyAsString(CONN_SESSION_EXPIRY_INTERVAL, "0");
+	}
+
+	public void setConnSessionExpiryInterval(String sessionExpiryInterval) {
+		setProperty(CONN_SESSION_EXPIRY_INTERVAL, sessionExpiryInterval);
+	}
+
+	public String getConnUserProperty() {
+		return getPropertyAsString(CONN_USER_PROPERTY, "{}");
+	}
+
+	public void setConnUserProperty(String connUserProperty) {
+		setProperty(CONN_USER_PROPERTY, connUserProperty);
+	}
+
+	public String getCAFilePath() {
+		return getPropertyAsString("mqtt.ca_file_path", "");
+	}
+
+	public void setCAFilePath(String ca) {
+		setProperty("mqtt.ca_file_path", ca);
+	}
+
+	public String getClientCert2FilePath() {
+		return getPropertyAsString("mqtt.client_cert_file_path", "");
+	}
+
+	public void setClientCert2FilePath(String cert) {
+		setProperty("mqtt.client_cert_file_path", cert);
+	}
+
+	public String getClientPrivateKeyFilePath() {
+		return getPropertyAsString("mqtt.client_key_file_path", "");
+	}
+
+	public void setClientPrivateKeyFilePath(String key) {
+		setProperty("mqtt.client_key_file_path", key);
+	}
+
+	public String getAuthMethod() {
+		return getPropertyAsString(AUTH_METHOD, "");
+	}
+
+	public void setAuthMethod(String authMethod) {
+		setProperty(AUTH_METHOD, authMethod);
+	}
+
+	public String getAuthData() {
+		return getPropertyAsString(AUTH_DATA, "");
+	}
+
+	public void setAuthData(String authData) {
+		setProperty(AUTH_DATA, authData);
 	}
 
 //	public int getConCapacity() {

--- a/mqtt_jmeter/src/main/java/net/xmeter/samplers/ConnectSampler.java
+++ b/mqtt_jmeter/src/main/java/net/xmeter/samplers/ConnectSampler.java
@@ -75,6 +75,13 @@ public class ConnectSampler extends AbstractMQTTSampler {
 				MQTTSsl ssl = MQTT.getInstance(getMqttClientName()).createSsl(this);
 				parameters.setSsl(ssl);
 			}
+
+			parameters.setConnUserProperty(getConnUserProperty());
+			parameters.setCleanStart(Boolean.parseBoolean(getConnCleanStart()));
+			parameters.setSessionExpiryInterval(Long.parseLong(getConnSessionExpiryInterval()));
+			parameters.setConnWsHeader(getWsHeader());
+			parameters.setAuthMethod(getAuthMethod());
+			parameters.setAuthData(getAuthData());
 		} catch (Exception e) {
 			logger.log(Level.SEVERE, "Failed to establish Connection " + connection , e);
 			result.setSuccessful(false);
@@ -83,7 +90,7 @@ public class ConnectSampler extends AbstractMQTTSampler {
 			result.setResponseCode("502");
 			return result;
 		}
-		
+
 		try {
 			client = MQTT.getInstance(getMqttClientName()).createClient(parameters);
 

--- a/mqtt_jmeter/src/main/java/net/xmeter/samplers/ConnectSampler.java
+++ b/mqtt_jmeter/src/main/java/net/xmeter/samplers/ConnectSampler.java
@@ -80,8 +80,6 @@ public class ConnectSampler extends AbstractMQTTSampler {
 			parameters.setCleanStart(Boolean.parseBoolean(getConnCleanStart()));
 			parameters.setSessionExpiryInterval(Long.parseLong(getConnSessionExpiryInterval()));
 			parameters.setConnWsHeader(getWsHeader());
-			parameters.setAuthMethod(getAuthMethod());
-			parameters.setAuthData(getAuthData());
 		} catch (Exception e) {
 			logger.log(Level.SEVERE, "Failed to establish Connection " + connection , e);
 			result.setSuccessful(false);

--- a/mqtt_jmeter/src/main/java/net/xmeter/samplers/PubSampler.java
+++ b/mqtt_jmeter/src/main/java/net/xmeter/samplers/PubSampler.java
@@ -6,6 +6,7 @@ import java.util.logging.Logger;
 
 import javax.xml.bind.DatatypeConverter;
 
+import net.xmeter.samplers.mqtt.MQTT5PublishReq;
 import org.apache.jmeter.samplers.Entry;
 import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.threads.JMeterContextService;
@@ -82,6 +83,70 @@ public class PubSampler extends AbstractMQTTSampler {
 		return getPropertyAsBoolean(RETAINED_MESSAGE, false);
 	}
 
+	public void setMessageExpiryInterval(long messageExpiryInterval) {
+		setProperty(MESSAGE_EXPIRY_INTERVAL, messageExpiryInterval);
+	}
+
+	public Long getMessageExpiryInterval() {
+		return getPropertyAsLong(MESSAGE_EXPIRY_INTERVAL);
+	}
+
+	public void setContentType(String contentType) {
+		setProperty(CONTENT_TYPE, contentType);
+	}
+
+	public String getContentType() {
+		return getPropertyAsString(CONTENT_TYPE);
+	}
+
+	public void setResponseTopic(String responseTopic) {
+		setProperty(RESPONSE_TOPIC, responseTopic);
+	}
+
+	public String getResponseTopic() {
+		return getPropertyAsString(RESPONSE_TOPIC);
+	}
+
+	public void setUserProperties(String userProperties) {
+		setProperty(USER_PROPERTIES, userProperties);
+	}
+
+	public String getUserProperties() {
+		return getPropertyAsString(USER_PROPERTIES);
+	}
+
+	public void setCorrelationData(String correlationData) {
+		setProperty(CORRELATION_DATA, correlationData);
+	}
+
+	public String getCorrelationData() {
+		return getPropertyAsString(CORRELATION_DATA);
+	}
+
+	public void setPayloadFormat(String payloadFormat) {
+		setProperty(PAYLOAD_FORMAT, payloadFormat);
+	}
+
+	public String getPayloadFormat() {
+		return getPropertyAsString(PAYLOAD_FORMAT);
+	}
+
+	public void setTopicAlias(String topicAlias) {
+		setProperty(TOPIC_ALIAS, topicAlias);
+	}
+
+	public String getTopicAlias() {
+		return getPropertyAsString(TOPIC_ALIAS);
+	}
+
+	public void setSubscriptionIdentifier(String subscriptionIdentifier) {
+		setProperty(SUBSCRIPTION_IDENTIFIER, subscriptionIdentifier);
+	}
+
+	public String getSubscriptionIdentifier() {
+		return getPropertyAsString(SUBSCRIPTION_IDENTIFIER);
+	}
+
 	public static byte[] hexToBinary(String hex) {
 	    return DatatypeConverter.parseHexBinary(hex);
 	}
@@ -119,7 +184,6 @@ public class PubSampler extends AbstractMQTTSampler {
 				tmp = payload.getBytes();
 			}
 
-			
 			int qos = Integer.parseInt(getQOS());
 			switch (qos) {
 			case 0:
@@ -146,13 +210,15 @@ public class PubSampler extends AbstractMQTTSampler {
 				toSend = new byte[tmp.length];
 				System.arraycopy(tmp, 0, toSend, 0 , tmp.length);
 			}
-			
+
+			MQTT5PublishReq mqtt5PublishReq = getMqtt5PublishReq();
+
 			result.sampleStart();
 			if (logger.isLoggable(Level.FINE)) {
 				logger.fine("pub [topic]: " + topicName + ", [payload]: " + new String(toSend));
 			}
 
-			MQTTPubResult pubResult = connection.publish(topicName, toSend, qos_enum, retainedMsg);
+			MQTTPubResult pubResult = connection.publish(topicName, toSend, qos_enum, retainedMsg, mqtt5PublishReq);
 			
 			result.sampleEnd();
 			result.setSamplerData(new String(toSend));
@@ -161,7 +227,7 @@ public class PubSampler extends AbstractMQTTSampler {
 			result.setSuccessful(pubResult.isSuccessful());
 			
 			if(pubResult.isSuccessful()) {
-				result.setResponseData("Publish successfuly.".getBytes());
+				result.setResponseData("Publish successfully.".getBytes());
 				result.setResponseMessage(MessageFormat.format("publish successfully for Connection {0}.", connection));
 				result.setResponseCodeOK();	
 			} else {
@@ -188,5 +254,19 @@ public class PubSampler extends AbstractMQTTSampler {
 		}
 		return result;
 	}
-	
+
+	private MQTT5PublishReq getMqtt5PublishReq() {
+		MQTT5PublishReq mqtt5PublishReq = new MQTT5PublishReq();
+		mqtt5PublishReq.setContentType(getContentType());
+		mqtt5PublishReq.setResponseTopic(getResponseTopic());
+		mqtt5PublishReq.setCorrelationData(getCorrelationData());
+		mqtt5PublishReq.setMessageExpiryInterval(getMessageExpiryInterval());
+		mqtt5PublishReq.setUserProperties(getUserProperties());
+		mqtt5PublishReq.setPayloadFormatIndicator(getPayloadFormat());
+		mqtt5PublishReq.setTopicAlias(getTopicAlias());
+		mqtt5PublishReq.setSubscriptionIdentifier(getSubscriptionIdentifier());
+
+		return mqtt5PublishReq;
+	}
+
 }

--- a/mqtt_jmeter/src/main/java/net/xmeter/samplers/mqtt/ConnectionParameters.java
+++ b/mqtt_jmeter/src/main/java/net/xmeter/samplers/mqtt/ConnectionParameters.java
@@ -27,8 +27,6 @@ public class ConnectionParameters {
     private long sessionExpiryInterval;
     private Map<String, String> connUserProperty;
     private Map<String, String> connWsHeader;
-    private String authMethod;
-    private String authData;
 
     public MQTTSsl getSsl() {
         return ssl;
@@ -219,21 +217,5 @@ public class ConnectionParameters {
                 "cleanStart='" + cleanStart + '\'' +
                 "sessionExpiryInterval='" + sessionExpiryInterval + '\'' +
                 '}';
-    }
-
-    public String getAuthMethod() {
-        return authMethod;
-    }
-
-    public void setAuthMethod(String authMethod) {
-        this.authMethod = authMethod;
-    }
-
-    public String getAuthData() {
-        return authData;
-    }
-
-    public void setAuthData(String authData) {
-        this.authData = authData;
     }
 }

--- a/mqtt_jmeter/src/main/java/net/xmeter/samplers/mqtt/ConnectionParameters.java
+++ b/mqtt_jmeter/src/main/java/net/xmeter/samplers/mqtt/ConnectionParameters.java
@@ -1,6 +1,11 @@
 package net.xmeter.samplers.mqtt;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import net.xmeter.Util;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 public class ConnectionParameters {
     private MQTTSsl ssl;
@@ -17,6 +22,13 @@ public class ConnectionParameters {
     private String password;
     private boolean cleanSession;
     private String path;
+
+    private boolean cleanStart;
+    private long sessionExpiryInterval;
+    private Map<String, String> connUserProperty;
+    private Map<String, String> connWsHeader;
+    private String authMethod;
+    private String authData;
 
     public MQTTSsl getSsl() {
         return ssl;
@@ -137,5 +149,91 @@ public class ConnectionParameters {
 
     public boolean isWebSocketProtocol() {
         return Util.isWebSocketProtocol(getProtocol());
+    }
+
+    public boolean isCleanStart() {
+        return cleanStart;
+    }
+
+    public void setCleanStart(boolean cleanStart) {
+        this.cleanStart = cleanStart;
+    }
+
+    public long getSessionExpiryInterval() {
+        return sessionExpiryInterval;
+    }
+
+    public void setSessionExpiryInterval(long sessionExpiryInterval) {
+        this.sessionExpiryInterval = sessionExpiryInterval;
+    }
+
+    public Map<String, String> getConnUserProperty() {
+        return connUserProperty;
+    }
+
+    public void setConnUserProperty(String userPropertyJson) {
+        if (userPropertyJson == null || userPropertyJson.isEmpty()) {
+            this.connUserProperty = new HashMap<>();
+            return;
+        }
+
+        ObjectMapper mapper = new ObjectMapper();
+        try{
+            this.connUserProperty = mapper.readValue(userPropertyJson, Map.class);
+        }catch (IOException e){
+            this.connUserProperty = new HashMap<>();
+            e.printStackTrace();
+        }
+    }
+
+    public Map<String, String> getConnWsHeader() {
+        return connWsHeader;
+    }
+
+    public void setConnWsHeader(String wsHeaderJson) {
+        if (wsHeaderJson == null || wsHeaderJson.isEmpty()) {
+            this.connWsHeader = new HashMap<>();
+            return;
+        }
+
+        ObjectMapper mapper = new ObjectMapper();
+        try{
+            this.connWsHeader = mapper.readValue(wsHeaderJson, Map.class);
+        }catch (IOException e){
+            this.connWsHeader = new HashMap<>();
+            e.printStackTrace();
+        }
+    }
+
+    public boolean shouldAutomaticReconnectWithDefaultConfig(){
+        return reconnectMaxAttempts == -1 || reconnectMaxAttempts > 0;
+    }
+
+    @Override
+    public String toString() {
+        return "ConnectionParameters{" +
+                "host='" + host + '\'' +
+                "port='" + port + '\'' +
+                "version='" + version + '\'' +
+                "connUserProperty='" + connUserProperty + '\'' +
+                "cleanStart='" + cleanStart + '\'' +
+                "sessionExpiryInterval='" + sessionExpiryInterval + '\'' +
+                '}';
+    }
+
+    public String getAuthMethod() {
+        return authMethod;
+    }
+
+    public void setAuthMethod(String authMethod) {
+        this.authMethod = authMethod;
+    }
+
+    public String getAuthData() {
+        return authData;
+    }
+
+    public void setAuthData(String authData) {
+        this.authData = authData;
     }
 }

--- a/mqtt_jmeter/src/main/java/net/xmeter/samplers/mqtt/MQTT5PublishReq.java
+++ b/mqtt_jmeter/src/main/java/net/xmeter/samplers/mqtt/MQTT5PublishReq.java
@@ -1,0 +1,94 @@
+package net.xmeter.samplers.mqtt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+public class MQTT5PublishReq {
+    private String correlationData;
+    private long messageExpiryInterval;
+    private Map<String, String> userProperties;
+    private String contentType;
+    private String responseTopic;
+
+    private String payloadFormatIndicator;
+    private String topicAlias;
+    private String subscriptionIdentifier;
+
+    public Map<String, String> getUserProperties() {
+        return userProperties;
+    }
+
+    public void setUserProperties(String userPropertiesJson) {
+        if (userPropertiesJson == null || userPropertiesJson.isEmpty()) {
+            this.userProperties = new HashMap<>();
+            return;
+        }
+
+        ObjectMapper mapper = new ObjectMapper();
+        try{
+            this.userProperties = mapper.readValue(userPropertiesJson, Map.class);
+        }catch (IOException e){
+            this.userProperties = new HashMap<>();
+            e.printStackTrace();
+        }
+    }
+
+    public String getCorrelationData() {
+        return correlationData;
+    }
+
+    public void setCorrelationData(String correlationData) {
+        this.correlationData = correlationData;
+    }
+
+    public long getMessageExpiryInterval() {
+        return messageExpiryInterval;
+    }
+
+    public void setMessageExpiryInterval(long messageExpiryInterval) {
+        this.messageExpiryInterval = messageExpiryInterval;
+    }
+
+    public String getContentType() {
+        return contentType;
+    }
+
+    public void setContentType(String contentType) {
+        this.contentType = contentType;
+    }
+
+    public String getResponseTopic() {
+        return responseTopic;
+    }
+
+    public void setResponseTopic(String responseTopic) {
+        this.responseTopic = responseTopic;
+    }
+
+    public String getPayloadFormatIndicator() {
+        return payloadFormatIndicator;
+    }
+
+    public void setPayloadFormatIndicator(String payloadFormatIndicator) {
+        this.payloadFormatIndicator = payloadFormatIndicator;
+    }
+
+    public String getTopicAlias() {
+        return topicAlias;
+    }
+
+    public void setTopicAlias(String topicAlias) {
+        this.topicAlias = topicAlias;
+    }
+
+    public String getSubscriptionIdentifier() {
+        return subscriptionIdentifier;
+    }
+
+    public void setSubscriptionIdentifier(String subscriptionIdentifier) {
+        this.subscriptionIdentifier = subscriptionIdentifier;
+    }
+}

--- a/mqtt_jmeter/src/main/java/net/xmeter/samplers/mqtt/MQTTConnection.java
+++ b/mqtt_jmeter/src/main/java/net/xmeter/samplers/mqtt/MQTTConnection.java
@@ -7,9 +7,10 @@ public interface MQTTConnection {
     String getClientId();
     void disconnect() throws Exception;
 
-    MQTTPubResult publish(String topicName, byte[] message, MQTTQoS qoS, boolean retained);
+    MQTTPubResult publish(String topicName, byte[] message, MQTTQoS qoS, boolean retained, MQTT5PublishReq req);
 
     void subscribe(String[] topicNames, MQTTQoS qos, Runnable onSuccess, Consumer<Throwable> onFailure);
 
     void setSubListener(MQTTSubListener listener);
 }
+

--- a/mqtt_jmeter/src/main/java/net/xmeter/samplers/mqtt/fuse/FuseMQTTConnection.java
+++ b/mqtt_jmeter/src/main/java/net/xmeter/samplers/mqtt/fuse/FuseMQTTConnection.java
@@ -8,6 +8,7 @@ import java.util.function.Consumer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import net.xmeter.samplers.mqtt.*;
 import org.fusesource.hawtbuf.Buffer;
 import org.fusesource.hawtbuf.UTF8Buffer;
 import org.fusesource.mqtt.client.Callback;
@@ -16,10 +17,6 @@ import org.fusesource.mqtt.client.Listener;
 import org.fusesource.mqtt.client.QoS;
 
 import net.xmeter.samplers.PubCallback;
-import net.xmeter.samplers.mqtt.MQTTConnection;
-import net.xmeter.samplers.mqtt.MQTTPubResult;
-import net.xmeter.samplers.mqtt.MQTTQoS;
-import net.xmeter.samplers.mqtt.MQTTSubListener;
 
 class FuseMQTTConnection implements MQTTConnection {
     private static final Logger logger = Logger.getLogger(FuseMQTTConnection.class.getCanonicalName());
@@ -63,7 +60,7 @@ class FuseMQTTConnection implements MQTTConnection {
     }
 
     @Override
-    public MQTTPubResult publish(String topicName, byte[] message, MQTTQoS qos, boolean retained) {
+    public MQTTPubResult publish(String topicName, byte[] message, MQTTQoS qos, boolean retained, MQTT5PublishReq req) {
         final Object pubLock = new Object();
         QoS fuseQos = FuseUtil.map(qos);
         PubCallback pubCallback = new PubCallback(pubLock, fuseQos);

--- a/mqtt_jmeter/src/main/java/net/xmeter/samplers/mqtt/hivemq/HiveMQTTConnection.java
+++ b/mqtt_jmeter/src/main/java/net/xmeter/samplers/mqtt/hivemq/HiveMQTTConnection.java
@@ -18,11 +18,7 @@ import com.hivemq.client.mqtt.mqtt3.message.subscribe.Mqtt3SubscribeBuilder;
 import com.hivemq.client.mqtt.mqtt3.message.subscribe.Mqtt3Subscription;
 import com.hivemq.client.mqtt.mqtt3.message.subscribe.suback.Mqtt3SubAckReturnCode;
 
-import net.xmeter.samplers.mqtt.MQTTClientException;
-import net.xmeter.samplers.mqtt.MQTTConnection;
-import net.xmeter.samplers.mqtt.MQTTPubResult;
-import net.xmeter.samplers.mqtt.MQTTQoS;
-import net.xmeter.samplers.mqtt.MQTTSubListener;
+import net.xmeter.samplers.mqtt.*;
 
 class HiveMQTTConnection implements MQTTConnection {
     private static final Logger logger = Logger.getLogger(HiveMQTTConnection.class.getCanonicalName());
@@ -56,7 +52,7 @@ class HiveMQTTConnection implements MQTTConnection {
     }
 
     @Override
-    public MQTTPubResult publish(String topicName, byte[] message, MQTTQoS qoS, boolean retained) {
+    public MQTTPubResult publish(String topicName, byte[] message, MQTTQoS qoS, boolean retained, MQTT5PublishReq req) {
         try {
             client.publishWith()
                     .topic(topicName)

--- a/mqtt_jmeter/src/main/java/net/xmeter/samplers/mqtt/paho/PahoMQTT3Client.java
+++ b/mqtt_jmeter/src/main/java/net/xmeter/samplers/mqtt/paho/PahoMQTT3Client.java
@@ -1,0 +1,71 @@
+package net.xmeter.samplers.mqtt.paho;
+
+import net.xmeter.Constants;
+import net.xmeter.samplers.mqtt.*;
+import org.eclipse.paho.client.mqttv3.*;
+import org.eclipse.paho.client.mqttv3.persist.MemoryPersistence;
+
+
+import java.util.function.Consumer;
+import java.util.logging.Logger;
+
+public class PahoMQTT3Client implements MQTTClient {
+
+    private static final Logger logger = Logger.getLogger(PahoMQTT3Client.class.getCanonicalName());
+    private final ConnectionParameters parameters;
+    private final MqttAsyncClient client;
+
+    PahoMQTT3Client(ConnectionParameters parameters) throws MqttException {
+        this.parameters = parameters;
+        MemoryPersistence persistence = new MemoryPersistence();
+        this.client = new MqttAsyncClient(PahoUtil.createHostAddress(parameters), this.getClientId(), persistence);
+    }
+
+
+    @Override
+    public String getClientId() {
+        return parameters.getClientId();
+    }
+
+    @Override
+    public MQTTConnection connect() throws Exception {
+
+        MqttConnectOptions connectOptions = new MqttConnectOptions();
+        connectOptions.setCleanSession(parameters.isCleanSession());
+        connectOptions.setKeepAliveInterval(parameters.getKeepAlive());
+        connectOptions.setConnectionTimeout(parameters.getConnectTimeout());
+
+        if (parameters.getVersion().equals(Constants.MQTT_VERSION_3_1_1)) {
+            connectOptions.setMqttVersion(MqttConnectOptions.MQTT_VERSION_3_1_1);
+        } else if (parameters.getVersion().equals(Constants.MQTT_VERSION_3_1)) {
+            connectOptions.setMqttVersion(MqttConnectOptions.MQTT_VERSION_3_1);
+        }
+
+        if (parameters.shouldAutomaticReconnectWithDefaultConfig()) {
+            connectOptions.setAutomaticReconnect(true);
+        }
+        if (parameters.getUsername() != null) {
+            connectOptions.setUserName(parameters.getUsername());
+        }
+        if (parameters.getPassword() != null) {
+            connectOptions.setPassword(parameters.getPassword().toCharArray());
+        }
+
+        if (parameters.isSecureProtocol()) {
+            PahoMQTTSsl ssl = (PahoMQTTSsl) parameters.getSsl();
+            connectOptions.setSocketFactory(PahoUtil.getSocketFactory(ssl.getCaFilePath(), ssl.getClientCertFilePath(), ssl.getClientKeyFilePath(), ""));
+        }
+
+        try {
+            client.connect(connectOptions)
+                    .waitForCompletion(parameters.getConnectTimeout() * 1000L);
+
+            logger.info(() -> "Connected client: " + parameters.getClientId());
+            return new PahoMQTT3Connection(client);
+        } catch (MqttException e) {
+            throw new MQTTClientException("Connection error " + client, e);
+        }
+    }
+}
+
+

--- a/mqtt_jmeter/src/main/java/net/xmeter/samplers/mqtt/paho/PahoMQTT3Connection.java
+++ b/mqtt_jmeter/src/main/java/net/xmeter/samplers/mqtt/paho/PahoMQTT3Connection.java
@@ -1,0 +1,98 @@
+package net.xmeter.samplers.mqtt.paho;
+
+import net.xmeter.samplers.mqtt.*;
+import org.eclipse.paho.client.mqttv3.*;
+
+import java.util.function.Consumer;
+import java.util.logging.Logger;
+
+class PahoMQTT3Connection implements MQTTConnection {
+
+    private static final Logger logger = Logger.getLogger(PahoMQTT3Connection.class.getCanonicalName());
+
+    private final MqttAsyncClient client;
+
+    private MQTTSubListener listener;
+
+    PahoMQTT3Connection(MqttAsyncClient client) {
+        this.client = client;
+    }
+
+    @Override
+    public boolean isConnectionSucc() {
+        return client.isConnected();
+    }
+
+    @Override
+    public String getClientId() {
+        return client.getClientId();
+    }
+
+    @Override
+    public void disconnect() throws Exception {
+        client.disconnect();
+    }
+
+    @Override
+    public MQTTPubResult publish(String topicName, byte[] message, MQTTQoS qoS, boolean retained, MQTT5PublishReq req) {
+        try {
+            MqttMessage msg = new MqttMessage();
+            msg.setPayload(message);
+            msg.setQos((PahoUtil.map(qoS)));
+            msg.setRetained(retained);
+            client.publish(topicName, msg);
+            return new MQTTPubResult(true);
+        } catch (Exception error) {
+            return new MQTTPubResult(false, error.getMessage());
+        }
+    }
+
+    @Override
+    public void subscribe(String[] topicNames, MQTTQoS qos, Runnable onSuccess, Consumer<Throwable> onFailure) {
+        int pahoQos = PahoUtil.map(qos);
+
+        for (String topicName : topicNames) {
+            try {
+                IMqttActionListener subListener = new IMqttActionListener() {
+                    @Override
+                    public void onSuccess(IMqttToken iMqttToken) {
+                        onSuccess.run();
+                    }
+
+                    @Override
+                    public void onFailure(IMqttToken iMqttToken, Throwable throwable) {
+                        onFailure.accept(throwable);
+                    }
+                };
+
+                client.subscribe(topicName, pahoQos, "", subListener, (topic, message) -> {
+                    try {
+                        handleMessageArrived(topic, message);
+                    } catch (Exception e) {
+                        logger.severe(e.getMessage());
+                    }
+                });
+            } catch (MqttException e) {
+                logger.warning("Failed to subscribe " + topicName + ", error: " + e.getMessage());
+            }
+        }
+    }
+
+    @Override
+    public void setSubListener(MQTTSubListener listener) {
+        this.listener = listener;
+    }
+
+    private void handleMessageArrived(String topic, MqttMessage message) {
+        this.listener.accept(topic, new String(message.getPayload()), () -> {
+        });
+    }
+
+    @Override
+    public String toString() {
+        return "PahoMQTT3Connection{" +
+                "clientId='" + client.getClientId() + '\'' +
+                '}';
+    }
+}
+

--- a/mqtt_jmeter/src/main/java/net/xmeter/samplers/mqtt/paho/PahoMQTT5Client.java
+++ b/mqtt_jmeter/src/main/java/net/xmeter/samplers/mqtt/paho/PahoMQTT5Client.java
@@ -1,0 +1,94 @@
+package net.xmeter.samplers.mqtt.paho;
+
+import net.xmeter.samplers.mqtt.ConnectionParameters;
+import net.xmeter.samplers.mqtt.MQTTClient;
+import net.xmeter.samplers.mqtt.MQTTClientException;
+import net.xmeter.samplers.mqtt.MQTTConnection;
+import org.eclipse.paho.mqttv5.client.*;
+import org.eclipse.paho.mqttv5.client.persist.MemoryPersistence;
+import org.eclipse.paho.mqttv5.common.MqttException;
+import org.eclipse.paho.mqttv5.common.MqttMessage;
+import org.eclipse.paho.mqttv5.common.packet.MqttProperties;
+import org.eclipse.paho.mqttv5.common.packet.UserProperty;
+
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.UnsupportedCallbackException;
+import javax.security.sasl.Sasl;
+import javax.security.sasl.SaslClient;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Logger;
+
+public class PahoMQTT5Client implements MQTTClient {
+
+    private static final Logger logger = Logger.getLogger(PahoMQTT5Client.class.getCanonicalName());
+    private final ConnectionParameters parameters;
+    private final MqttAsyncClient client;
+
+    PahoMQTT5Client(ConnectionParameters parameters) throws MqttException {
+        this.parameters = parameters;
+        MemoryPersistence persistence = new MemoryPersistence();
+        this.client = new MqttAsyncClient(PahoUtil.createHostAddress(parameters), this.getClientId(), persistence);
+    }
+
+
+    @Override
+    public String getClientId() {
+        return parameters.getClientId();
+    }
+
+    @Override
+    public MQTTConnection connect() throws Exception {
+
+        MqttConnectionOptions connectOptions = new MqttConnectionOptions();
+        connectOptions.setCleanStart(parameters.isCleanStart());
+        connectOptions.setKeepAliveInterval(parameters.getKeepAlive());
+        connectOptions.setConnectionTimeout(parameters.getConnectTimeout());
+        connectOptions.setSessionExpiryInterval(parameters.getSessionExpiryInterval());
+
+        List<UserProperty> userProperty = PahoUtil.ConvertUserProperty(parameters.getConnUserProperty());
+        if (!userProperty.isEmpty()) {
+            connectOptions.setUserProperties(userProperty);
+        }
+
+        if (parameters.shouldAutomaticReconnectWithDefaultConfig()) {
+            connectOptions.setAutomaticReconnect(true);
+        }
+        if (parameters.getUsername() != null) {
+            connectOptions.setUserName(parameters.getUsername());
+        }
+        if (parameters.getPassword() != null) {
+            connectOptions.setPassword(parameters.getPassword().getBytes());
+        }
+
+        if (parameters.isSecureProtocol()) {
+            PahoMQTTSsl ssl = (PahoMQTTSsl) parameters.getSsl();
+            connectOptions.setSocketFactory(PahoUtil.getSocketFactory(ssl.getCaFilePath(), ssl.getClientCertFilePath(), ssl.getClientKeyFilePath(), ""));
+        }
+
+        if (parameters.getConnWsHeader() != null && !parameters.getConnWsHeader().isEmpty()) {
+            connectOptions.setCustomWebSocketHeaders(parameters.getConnWsHeader());
+        }
+
+//        if (parameters.getAuthMethod() != null && !parameters.getAuthMethod().isEmpty()) {
+//            connectOptions.setAuthMethod(parameters.getAuthMethod());
+//        }
+
+//        if (parameters.getAuthData() != null && !parameters.getAuthData().isEmpty()) {
+//            connectOptions.setAuthData(parameters.getAuthData().getBytes());
+//        }
+
+        try {
+            client.connect(connectOptions)
+                    .waitForCompletion(parameters.getConnectTimeout() * 1000L);
+
+            logger.info(() -> "Connected client: " + parameters.getClientId());
+            return new PahoMQTT5Connection(client);
+        } catch (MqttException e) {
+            throw new MQTTClientException("Connection error " + client, e);
+        }
+    }
+}

--- a/mqtt_jmeter/src/main/java/net/xmeter/samplers/mqtt/paho/PahoMQTT5Client.java
+++ b/mqtt_jmeter/src/main/java/net/xmeter/samplers/mqtt/paho/PahoMQTT5Client.java
@@ -73,14 +73,6 @@ public class PahoMQTT5Client implements MQTTClient {
             connectOptions.setCustomWebSocketHeaders(parameters.getConnWsHeader());
         }
 
-//        if (parameters.getAuthMethod() != null && !parameters.getAuthMethod().isEmpty()) {
-//            connectOptions.setAuthMethod(parameters.getAuthMethod());
-//        }
-
-//        if (parameters.getAuthData() != null && !parameters.getAuthData().isEmpty()) {
-//            connectOptions.setAuthData(parameters.getAuthData().getBytes());
-//        }
-
         try {
             client.connect(connectOptions)
                     .waitForCompletion(parameters.getConnectTimeout() * 1000L);

--- a/mqtt_jmeter/src/main/java/net/xmeter/samplers/mqtt/paho/PahoMQTT5Connection.java
+++ b/mqtt_jmeter/src/main/java/net/xmeter/samplers/mqtt/paho/PahoMQTT5Connection.java
@@ -1,0 +1,185 @@
+package net.xmeter.samplers.mqtt.paho;
+
+
+import net.xmeter.samplers.mqtt.*;
+import org.eclipse.paho.mqttv5.client.*;
+import org.eclipse.paho.mqttv5.common.MqttException;
+import org.eclipse.paho.mqttv5.common.MqttMessage;
+import org.eclipse.paho.mqttv5.common.MqttSubscription;
+import org.eclipse.paho.mqttv5.common.packet.MqttProperties;
+import org.eclipse.paho.mqttv5.common.packet.UserProperty;
+
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.logging.Logger;
+
+class PahoMQTT5Connection implements MQTTConnection {
+
+    private static final Logger logger = Logger.getLogger(PahoMQTT5Connection.class.getCanonicalName());
+
+    private final MqttAsyncClient client;
+
+    private MQTTSubListener listener;
+
+    PahoMQTT5Connection(MqttAsyncClient client) {
+        this.client = client;
+    }
+
+    @Override
+    public boolean isConnectionSucc() {
+        return client.isConnected();
+    }
+
+    @Override
+    public String getClientId() {
+        return client.getClientId();
+    }
+
+    @Override
+    public void disconnect() throws Exception {
+        client.disconnect();
+    }
+
+    @Override
+    public MQTTPubResult publish(String topicName, byte[] message, MQTTQoS qoS, boolean retained, MQTT5PublishReq req) {
+        try {
+            MqttMessage msg = new MqttMessage();
+            msg.setPayload(message);
+            msg.setQos((PahoUtil.map(qoS)));
+            msg.setRetained(retained);
+            msg.setProperties(buildMqtt5MessageFeature(req));
+
+            client.publish(topicName, msg);
+            return new MQTTPubResult(true);
+        } catch (Exception error) {
+            return new MQTTPubResult(false, error.getMessage());
+        }
+    }
+
+    @Override
+    public void subscribe(String[] topicNames, MQTTQoS qos, Runnable onSuccess, Consumer<Throwable> onFailure) {
+        int pahoQos = PahoUtil.map(qos);
+
+        for (String topicName : topicNames) {
+            try {
+
+                MqttActionListener subListener = new MqttActionListener() {
+                    @Override
+                    public void onSuccess(IMqttToken iMqttToken) {
+                        onSuccess.run();
+                    }
+
+                    @Override
+                    public void onFailure(IMqttToken iMqttToken, Throwable throwable) {
+                        onFailure.accept(throwable);
+                    }
+                };
+
+                // the subscribe method has issue when pass MqttActionListener and IMqttMessageListener
+                // https://github.com/eclipse/paho.mqtt.java/issues/1019
+                // https://github.com/eclipse/paho.mqtt.java/issues/826
+                // for `messageArrived` use `client.setCallback` to replace at this time.
+                client.setCallback(new MqttCallback() {
+                    @Override
+                    public void disconnected(MqttDisconnectResponse mqttDisconnectResponse) {
+
+                    }
+
+                    @Override
+                    public void mqttErrorOccurred(MqttException e) {
+
+                    }
+
+                    @Override
+                    public void messageArrived(String topic, MqttMessage message) throws Exception {
+                        try {
+                            handleMessageArrived(topic, message);
+                        } catch (Exception e) {
+                            logger.severe(e.getMessage());
+                        }
+                    }
+
+                    @Override
+                    public void deliveryComplete(IMqttToken iMqttToken) {
+
+                    }
+
+                    @Override
+                    public void connectComplete(boolean b, String s) {
+
+                    }
+
+                    @Override
+                    public void authPacketArrived(int i, MqttProperties mqttProperties) {
+
+                    }
+                });
+
+//                MqttSubscription mqttSubscription = new MqttSubscription(topicName);
+//                mqttSubscription.setQos(pahoQos);
+//                mqttSubscription.setNoLocal(false);
+//                mqttSubscription.setRetainHandling(0);
+//                mqttSubscription.setRetainAsPublished(false);
+
+                client.subscribe(topicName, pahoQos, "", subListener);
+            } catch (MqttException e) {
+                logger.warning("Failed to subscribe " + topicName + ", error: " + e.getMessage());
+            }
+        }
+    }
+
+    @Override
+    public void setSubListener(MQTTSubListener listener) {
+        this.listener = listener;
+    }
+
+    private void handleMessageArrived(String topic, MqttMessage message) {
+        this.listener.accept(topic, new String(message.getPayload()), () -> {
+        });
+    }
+
+    private MqttProperties buildMqtt5MessageFeature(MQTT5PublishReq req){
+        MqttProperties properties = new MqttProperties();
+        properties.setMessageExpiryInterval(req.getMessageExpiryInterval());
+
+        if (req.getCorrelationData() != null && !req.getCorrelationData().trim().isEmpty()) {
+            properties.setCorrelationData(req.getCorrelationData().getBytes());
+        }
+
+        List<UserProperty> userProperty = PahoUtil.ConvertUserProperty(req.getUserProperties());
+        if (!userProperty.isEmpty()) {
+            properties.setUserProperties(userProperty);
+        }
+
+        if (req.getResponseTopic() != null && !req.getResponseTopic().isEmpty()) {
+            properties.setResponseTopic(req.getResponseTopic());
+        }
+
+        if (req.getContentType() != null && !req.getContentType().isEmpty()){
+            properties.setContentType(req.getContentType());
+        }
+
+        if (!req.getPayloadFormatIndicator().isEmpty()) {
+            properties.setPayloadFormat(req.getPayloadFormatIndicator().equals("UTF_8"));
+        }
+
+        if (req.getTopicAlias() != null && !req.getTopicAlias().isEmpty()) {
+            properties.setTopicAlias(Integer.parseInt(req.getTopicAlias()));
+        }
+
+        if (req.getSubscriptionIdentifier() != null && !req.getSubscriptionIdentifier().isEmpty()) {
+            properties.setSubscriptionIdentifier(Integer.parseInt(req.getSubscriptionIdentifier()));
+        }
+
+//        logger.severe(properties.toString());
+
+        return properties;
+    }
+
+    @Override
+    public String toString() {
+        return "PahoMQTT5Connection{" +
+                "clientId='" + client.getClientId() + '\'' +
+                '}';
+    }
+}

--- a/mqtt_jmeter/src/main/java/net/xmeter/samplers/mqtt/paho/PahoMQTTFactory.java
+++ b/mqtt_jmeter/src/main/java/net/xmeter/samplers/mqtt/paho/PahoMQTTFactory.java
@@ -1,0 +1,46 @@
+package net.xmeter.samplers.mqtt.paho;
+
+import net.xmeter.Constants;
+import net.xmeter.Util;
+import net.xmeter.samplers.AbstractMQTTSampler;
+import net.xmeter.samplers.mqtt.ConnectionParameters;
+import net.xmeter.samplers.mqtt.MQTTClient;
+import net.xmeter.samplers.mqtt.MQTTFactory;
+import net.xmeter.samplers.mqtt.MQTTSsl;
+
+import java.util.List;
+
+class PahoMQTTFactory implements MQTTFactory {
+    @Override
+    public String getName() {
+        return Constants.PAHO_MQTT_CLIENT_NAME;
+    }
+
+    @Override
+    public List<String> getSupportedProtocols() {
+        return PahoUtil.ALLOWED_PROTOCOLS;
+    }
+
+    @Override
+    public MQTTClient createClient(ConnectionParameters parameters) throws Exception {
+        String mqttVersion = parameters.getVersion();
+        if (Constants.MQTT_VERSION_3_1.equals(mqttVersion) || Constants.MQTT_VERSION_3_1_1.equals(mqttVersion)){
+            return new PahoMQTT3Client(parameters);
+        }
+        else {
+            return new PahoMQTT5Client(parameters);
+        }
+    }
+
+    @Override
+    public MQTTSsl createSsl(AbstractMQTTSampler sampler) throws Exception {
+        if (!sampler.isDualSSLAuth()){
+            return  new PahoMQTTSsl("","","");
+        } else {
+            return  new PahoMQTTSsl(
+                    sampler.getCAFilePath(),
+                    sampler.getClientCert2FilePath(),
+                    sampler.getClientPrivateKeyFilePath());
+        }
+    }
+}

--- a/mqtt_jmeter/src/main/java/net/xmeter/samplers/mqtt/paho/PahoMQTTSpi.java
+++ b/mqtt_jmeter/src/main/java/net/xmeter/samplers/mqtt/paho/PahoMQTTSpi.java
@@ -1,0 +1,11 @@
+package net.xmeter.samplers.mqtt.paho;
+
+import net.xmeter.samplers.mqtt.*;
+
+
+public class PahoMQTTSpi implements MQTTSpi {
+    @Override
+    public MQTTFactory factory() {
+        return new PahoMQTTFactory();
+    }
+}

--- a/mqtt_jmeter/src/main/java/net/xmeter/samplers/mqtt/paho/PahoMQTTSsl.java
+++ b/mqtt_jmeter/src/main/java/net/xmeter/samplers/mqtt/paho/PahoMQTTSsl.java
@@ -1,0 +1,38 @@
+package net.xmeter.samplers.mqtt.paho;
+
+import net.xmeter.samplers.mqtt.MQTTSsl;
+
+import javax.net.ssl.SSLContext;
+
+class PahoMQTTSsl implements MQTTSsl {
+    private final String caFilePath;
+    private final String clientCertFilePath;
+    private final String clientKeyFilePath;
+
+    PahoMQTTSsl(String ca, String cc, String ck) {
+        this.caFilePath = ca;
+        this.clientCertFilePath = cc;
+        this.clientKeyFilePath = ck;
+    }
+
+    String getCaFilePath(){
+        return caFilePath;
+    }
+
+    String getClientCertFilePath(){
+        return clientCertFilePath;
+    }
+
+    String getClientKeyFilePath(){
+        return  clientKeyFilePath;
+    }
+
+    @Override
+    public String toString() {
+        return "PahoMQTTSsl{" +
+                "ca='" + caFilePath + '\'' +
+                "cc='" + clientCertFilePath + '\'' +
+                "ck='" + clientKeyFilePath + '\'' +
+                '}';
+    }
+}

--- a/mqtt_jmeter/src/main/java/net/xmeter/samplers/mqtt/paho/PahoUtil.java
+++ b/mqtt_jmeter/src/main/java/net/xmeter/samplers/mqtt/paho/PahoUtil.java
@@ -1,0 +1,146 @@
+package net.xmeter.samplers.mqtt.paho;
+
+import java.io.BufferedInputStream;
+import java.io.FileInputStream;
+import java.io.FileReader;
+import java.security.KeyPair;
+import java.security.KeyStore;
+import java.security.Security;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.TrustManagerFactory;
+
+import com.hivemq.client.mqtt.datatypes.MqttQos;
+import net.xmeter.Constants;
+import net.xmeter.samplers.mqtt.ConnectionParameters;
+import net.xmeter.samplers.mqtt.MQTTQoS;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.openssl.PEMDecryptorProvider;
+import org.bouncycastle.openssl.PEMEncryptedKeyPair;
+import org.bouncycastle.openssl.PEMKeyPair;
+import org.bouncycastle.openssl.PEMParser;
+import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
+import org.bouncycastle.openssl.jcajce.JcePEMDecryptorProviderBuilder;
+import org.eclipse.paho.mqttv5.common.packet.UserProperty;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+class PahoUtil {
+    static final List<String> ALLOWED_PROTOCOLS;
+
+    static {
+        ALLOWED_PROTOCOLS = new ArrayList<>();
+        ALLOWED_PROTOCOLS.add(Constants.TCP_PROTOCOL);
+        ALLOWED_PROTOCOLS.add(Constants.SSL_PROTOCOL);
+        ALLOWED_PROTOCOLS.add(Constants.WS_PROTOCOL);
+        ALLOWED_PROTOCOLS.add(Constants.WSS_PROTOCOL);
+    }
+
+    static int map(MQTTQoS qos) {
+        switch (qos) {
+            case AT_MOST_ONCE:
+                return 0;
+            case AT_LEAST_ONCE:
+                return 1;
+            case EXACTLY_ONCE:
+                return 2;
+            default:
+                throw new IllegalArgumentException("Unknown QoS: " + qos);
+        }
+    }
+
+    static String createHostAddress(ConnectionParameters parameters) {
+        return String.format("%s://%s:%d",
+                parameters.getProtocol().toLowerCase(),
+                parameters.getHost(),
+                parameters.getPort());
+    }
+
+    static List<UserProperty> ConvertUserProperty(Map<String, String> userProperty) {
+        if (!userProperty.isEmpty()) {
+            ArrayList<UserProperty> userDefinedProperties = new ArrayList<>();
+            for (Map.Entry<String, String> entry : userProperty.entrySet()) {
+                userDefinedProperties.add(new UserProperty(entry.getKey(), entry.getValue()));
+            }
+            return userDefinedProperties;
+        } else {
+            return new ArrayList<UserProperty>();
+        }
+    }
+
+    static SSLSocketFactory getSingleSocketFactory(final String caCrtFile) throws Exception {
+        Security.addProvider(new BouncyCastleProvider());
+
+        // Load CA certificates
+        KeyStore caKs = loadCAKeyStore(caCrtFile);
+        TrustManagerFactory tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+        tmf.init(caKs);
+        SSLContext sslContext = SSLContext.getInstance("TLSv1.2");
+        sslContext.init(null, tmf.getTrustManagers(), null);
+        return sslContext.getSocketFactory();
+    }
+
+    static SSLSocketFactory getSocketFactory(final String caCrtFile,
+                                                    final String crtFile, final String keyFile, final String password)
+            throws Exception {
+        Security.addProvider(new BouncyCastleProvider());
+
+        // Load CA certificates
+        KeyStore caKs = loadCAKeyStore(caCrtFile);
+
+        // Load client certificate chain and key
+        KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());
+        ks.load(null, null);
+
+        // Load the entire client certificate chain
+        Certificate[] chain;
+        try (FileInputStream fis = new FileInputStream(crtFile)) {
+            CertificateFactory cf = CertificateFactory.getInstance("X.509");
+            Collection<? extends Certificate> certs = cf.generateCertificates(fis);
+            chain = certs.toArray(new Certificate[0]);
+        }
+
+        // Load client private key
+        try (PEMParser pemParser = new PEMParser(new FileReader(keyFile))) {
+            Object object = pemParser.readObject();
+            JcaPEMKeyConverter converter = new JcaPEMKeyConverter().setProvider("BC");
+            KeyPair key = converter.getKeyPair((PEMKeyPair) object);
+            ks.setKeyEntry("private-key", key.getPrivate(), password.toCharArray(), chain);
+        }
+
+        // Set up key managers and trust managers
+        TrustManagerFactory tmf = TrustManagerFactory.getInstance("X509");
+        tmf.init(caKs);
+        KeyManagerFactory kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+        kmf.init(ks, password.toCharArray());
+
+        // finally, create SSL socket factory
+        SSLContext context = SSLContext.getInstance("TLSv1.2");
+        context.init(kmf.getKeyManagers(), tmf.getTrustManagers(), null);
+
+        return context.getSocketFactory();
+    }
+
+    private static KeyStore loadCAKeyStore(String caCrtFile) throws Exception {
+        KeyStore caKs = KeyStore.getInstance(KeyStore.getDefaultType());
+        caKs.load(null, null);
+        try (FileInputStream fis = new FileInputStream(caCrtFile)) {
+            CertificateFactory cf = CertificateFactory.getInstance("X.509");
+            Collection<? extends Certificate> caCerts = cf.generateCertificates(fis);
+            int certIndex = 1;
+            for (Certificate caCert : caCerts) {
+                String alias = "ca-certificate-" + certIndex++;
+                caKs.setCertificateEntry(alias, caCert);
+            }
+        }
+        return caKs;
+    }
+}

--- a/mqtt_jmeter/src/main/resources/META-INF/services/net.xmeter.samplers.mqtt.MQTTSpi
+++ b/mqtt_jmeter/src/main/resources/META-INF/services/net.xmeter.samplers.mqtt.MQTTSpi
@@ -1,2 +1,3 @@
 net.xmeter.samplers.mqtt.fuse.FuseMQTTSpi
 net.xmeter.samplers.mqtt.hivemq.HiveMQTTSpi
+net.xmeter.samplers.mqtt.paho.PahoMQTTSpi


### PR DESCRIPTION
This PR did the following things:

1. Introduce Paho MQTT client both v3 and v5, and set the default client to it.
2. Add `UserProperty`, `CleanStart` and `SessionExpiryInterval` in Conn Pannel.
3. Add `WS Header` in Protocol Panel
4. Add `UserProperties`, `MessageExpiryInterval`, `TopicAlias`, `PayloadFormat`,`ContentType` ,`ResponseTopic`,`CorrelationData` and `SubscriptionIdentifier` in Publish Option Pannel
5. Replace `p12` cert with `CA Cert`, `Client Cert` and `Client Private Key` when using dual ssl.

